### PR TITLE
Performance

### DIFF
--- a/clj-browserchannel-server/src/net/thegeez/browserchannel.clj
+++ b/clj-browserchannel-server/src/net/thegeez/browserchannel.clj
@@ -352,7 +352,10 @@
                (let [next-array-id (inc last-sent-array-id)]
                  (-> this
                      (assoc :last-sent-array-id next-array-id)
-                     (update-in [:to-acknowledge-buffer] conj [next-array-id string])
+                     (update-in [:to-acknowledge-buffer]
+                       #(if (not= string "[\"noop\"]")
+                            (conj % [next-array-id string])
+                            %))
                      (update-in [:to-flush-buffer] conj [next-array-id string]))))
   (acknowledge-arrays [this array-id]
     (let [array-id (Long/parseLong array-id)


### PR DESCRIPTION
Refactor buffer data structures for performance and readability.

Now there are two queues- `to-flush-buffer`, and `to-acknowledge-buffer`.
- `send-string` pushes the array to both
- `acknowledge-arrays` truncates `to-acknowledge-buffer`, and assigns it to `to-flush-buffer`.
- `flush-buffer` uses `to-flush-buffer` and assigns it an empty queue on success.

Overall this should be not only faster, but easier to understand.
