### PR TITLE
pass incoming browserchannel message request maps to listeners

### DIFF
--- a/clj-browserchannel-jetty-adapter/project.clj
+++ b/clj-browserchannel-jetty-adapter/project.clj
@@ -1,10 +1,10 @@
-(defproject net.thegeez/clj-browserchannel-jetty-adapter "0.0.5"
+(defproject net.thegeez/clj-browserchannel-jetty-adapter "0.0.6"
   :description "Jetty async adapter for BrowserChannel"
   :url ""
   :dependencies [[ring/ring-core "1.3.1"]
                  [ring/ring-servlet "1.3.1"]
                  [org.eclipse.jetty/jetty-server "8.1.16.v20140903"];; includes ssl
-                 [net.thegeez/clj-browserchannel-server "0.0.9"]]
+                 [net.thegeez/clj-browserchannel-server "0.1.0"]]
   :profiles {:provided
               {:dependencies
                 [[org.clojure/clojure "1.6.0"]]}})

--- a/clj-browserchannel-server/project.clj
+++ b/clj-browserchannel-server/project.clj
@@ -1,4 +1,4 @@
-(defproject net.thegeez/clj-browserchannel-server "0.0.9"
+(defproject net.thegeez/clj-browserchannel-server "0.1.0"
   :description "BrowserChannel server implementation in Clojure"
   :dependencies [[ring/ring-core "1.3.1"]
                  [org.clojure/data.json "0.2.5"]]


### PR DESCRIPTION
The request map originating from incoming messages from clients is available in pretty much every place where a listener is invoked (except obviously for a :close event not originating from a client action), so it would be handy to have this passed to the listener function to allow application code to use this (e.g. to use up to date session data, cookies ... ).

Note that this change is not backwards compatible, as the request map now is always the first argument passed to listener functions. However, this is a very minor change to make in application code.

Before:

``` clojure
(browserchannel/add-listener
  session-id
  :map
  (fn [m]
    ; ...
    ))

(browserchannel/add-listener
  session-id
  :close
  (fn [reason]
    ; ...
    ))
```

After:

``` clojure
(browserchannel/add-listener
  session-id
  :map
  (fn [request m]
    ; ...
    ))

(browserchannel/add-listener
  session-id
  :close
  (fn [request reason]
    ; ...
    ))
```
